### PR TITLE
Polish README wording and fix AICoverGen Mod Colab badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AI-Song-Cover-RVC
-All in One Repository: Youtube WAV Download, Separating Vocal, Splitting Audio, Training, and Inference Using Google Colab or Kaggle.
+Everything you need for RVC voice covers in one place, run on Google Colab or Kaggle: download YouTube audio as WAV, separate vocals, split audio, train models, and run inference.
 ## Make Sure To Leave A Star If This Repo Was Helpful :)
 [![ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/R6R7AH1FA)
 <a href="https://trakteer.id/ardha27">
@@ -19,14 +19,14 @@ All in One Repository: Youtube WAV Download, Separating Vocal, Splitting Audio, 
 Read this [tutorial](https://noteardha.notion.site/noteardha/RVC-Training-69e4569b10ee429aae2a41bfb4bb18cc)
 ### Download Training Assets
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ardha27/AI-Song-Cover-RVC/blob/main/Download_Training_Assets.ipynb)
-### Run Training (Run Upper One First)
+### Run Training (Run the Asset Download Above First)
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ardha27/AI-Song-Cover-RVC/blob/main/TrainingV2_NoUI.ipynb)
 
 ## AICoverGen Mod by Me & Hina (Colab Free)
-- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://github.com/ardha27/AI-Song-Cover-RVC/blob/main/Hina_Mod_AICoverGen_colab.ipynb)
+- [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ardha27/AI-Song-Cover-RVC/blob/main/Hina_Mod_AICoverGen_colab.ipynb)
 
 ## AICoverGen by SociallyIneptWeeb (Without UI, Colab Pro Only)
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/ardha27/AICoverGen-NoUI-Colab/blob/main/CoverGen_No_UI.ipynb)
 
-## Training V2 and Youtube Audio Download & Splitting Audio Combined by MinatoIsuki (With UI, Colab Pro Only)
+## Training V2 with YouTube Audio Download and Splitting, Combined by MinatoIsuki (With UI, Colab Pro Only)
 - [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/MinatoIsuki/AI-Song-Cover-RVC/blob/main/Training_V2_and_Youtube_Audio_Download_%26_Splitting_Audio_combined.ipynb)


### PR DESCRIPTION
## What this changes

- Rewrite the run-on top description so it reads clearly while keeping the same meaning (all-in-one RVC toolkit on Colab/Kaggle for YouTube WAV download, vocal separation, audio splitting, training, and inference).
- Fix the **AICoverGen Mod by Me & Hina** badge. It pointed at a plain GitHub blob URL, so the "Open In Colab" button did not actually open Colab. It now uses the `colab.research.google.com/github/...` form, matching every other entry.
- Smooth two awkward section titles for readability.

## What this keeps

All Colab links and badges, the ko-fi and Trakteer support buttons, the Indonesian tutorial links, and the "Make Sure To Leave A Star" line. No entries removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)